### PR TITLE
Fix Dapper typo and add other projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Must read papers on distributed systems. While nearly *all* of Lamport's work sh
 - [Paxos made live - An engineering perspective](http://research.google.com/archive/paxos_made_live.html) Google's learning while implementing systems atop of Paxos. Demonstrates various practical issues encountered while implementing a theoritical concept.
 - [Raft Consensus Algorithm](https://raftconsensus.github.io/) An alternative to Paxos for distributed consensus, that is much simpler to understand. Do checkout an [interesting visualization of raft](http://thesecretlivesofdata.com/raft/)
 
-### Testing
+### Testing, monitoring and tracing
 While designing distributed systems are hard enough, testing them is even harder. 
-- [Drapper](http://static.googleusercontent.com/media/research.google.com/en//pubs/archive/36356.pdf), Google's large scale distributed-systems tracing infrastructure, this is also the basis for the open source [Zipkin](http://zipkin.io/) tool
+- [Dapper](http://static.googleusercontent.com/media/research.google.com/en//pubs/archive/36356.pdf), Google's large scale distributed-systems tracing infrastructure, this was also the basis for the design of open source projects such as [Zipkin](http://zipkin.io/), [Pinpoint](https://github.com/naver/pinpoint) and [HTrace](http://htrace.incubator.apache.org/).
 
 ## Courses
 - [Cloud Computing Concepts](https://class.coursera.org/cloudcomputing-001), University of Illinois


### PR DESCRIPTION
Fixed the name and added two other projects inspired by Dapper.
Also changed the section title which was a little misleading of the content.