### PR TITLE
removed slash in url to a-plain-english-introduction-to-cap-theorem

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Most links will tend to be readings on architecture itself rather than code itse
 
 ## Bootcamp
 Read things here before you start.
-- [CAP Theorem](http://en.wikipedia.org/wiki/CAP_theorem), Also [plain english](http://ksat.me/a-plain-english-introduction-to-cap-theorem/) explanation
+- [CAP Theorem](http://en.wikipedia.org/wiki/CAP_theorem), Also [plain english](http://ksat.me/a-plain-english-introduction-to-cap-theorem) explanation
 - [Fallacies of Distributed Computing](http://en.wikipedia.org/wiki/Fallacies_of_distributed_computing), expect things to break, *everything*
 - [Distributed systems theory for the distributed engineer](http://the-paper-trail.org/blog/distributed-systems-theory-for-the-distributed-systems-engineer/), most of the papers/books in the blog might reappear in this list again. Still a good BFS approach to distributed systems.
 - [FLP Impossibility Result (paper)](https://groups.csail.mit.edu/tds/papers/Lynch/jacm85.pdf), an easier [blog post](http://the-paper-trail.org/blog/a-brief-tour-of-flp-impossibility/) to follow along


### PR DESCRIPTION
removed trailing slash in the url to **a-plain-english-introduction-to-cap-theorem** as currently it results in **404** because of the slash in the url